### PR TITLE
docs: Add WebPage Node to glossary

### DIFF
--- a/glossary/node.mdx
+++ b/glossary/node.mdx
@@ -27,7 +27,7 @@ File node is used to handle file data. You can read files, use them as input for
 
 ### WebPage Node
 
-The WebPage node is used to fetch and hold content from web pages. You can input one or more URLs, and Giselle will attempt to retrieve the content from these pages. Currently, the fetched content is processed and made available primarily in Markdown format. This allows you to use web content as a dynamic input source for AI models or other processing nodes within your workflow, enabling tasks like summarization, analysis, or content generation based on information from the web. The UI for managing URLs and other WebPage Node features will be incrementally updated.
+The WebPage node is used to fetch and hold content from web pages. You can input one or more URLs, and Giselle will attempt to retrieve the content from these pages. Currently, the fetched content is processed and made available primarily in Markdown format. This allows you to use web content as a dynamic input source for AI models or other processing nodes within your workflow, enabling tasks like summarization, analysis, or content generation based on information from the web.
 
 ### Trigger Node
 

--- a/glossary/node.mdx
+++ b/glossary/node.mdx
@@ -27,7 +27,7 @@ File node is used to handle file data. You can read files, use them as input for
 
 ### WebPage Node
 
-The WebPage node is used to fetch and hold content from web pages. You can input one or more URLs, and Giselle will attempt to retrieve the content from these pages. Currently, the fetched content is processed and made available primarily in Markdown format. This allows you to use real-time web content as a dynamic input source for AI models or other processing nodes within your workflow, enabling tasks like summarization, analysis, or content generation based on information from the web. The UI for managing URLs and other WebPage Node features will be incrementally updated.
+The WebPage node is used to fetch and hold content from web pages. You can input one or more URLs, and Giselle will attempt to retrieve the content from these pages. Currently, the fetched content is processed and made available primarily in Markdown format. This allows you to use web content as a dynamic input source for AI models or other processing nodes within your workflow, enabling tasks like summarization, analysis, or content generation based on information from the web. The UI for managing URLs and other WebPage Node features will be incrementally updated.
 
 ### Trigger Node
 

--- a/glossary/node.mdx
+++ b/glossary/node.mdx
@@ -25,6 +25,10 @@ Text node is used to hold text data. It can be used to record prompts, instructi
 
 File node is used to handle file data. You can read files, use them as input for AI models, and save output results to files. It is useful for various tasks that involve utilizing file data, such as data-based analysis and report generation.
 
+### WebPage Node
+
+The WebPage node is used to fetch and hold content from web pages. You can input one or more URLs, and Giselle will attempt to retrieve the content from these pages. Currently, the fetched content is processed and made available primarily in Markdown format. This allows you to use real-time web content as a dynamic input source for AI models or other processing nodes within your workflow, enabling tasks like summarization, analysis, or content generation based on information from the web. The UI for managing URLs and other WebPage Node features will be incrementally updated.
+
 ### Trigger Node
 
 Trigger Node is the starting point for running the workflow built in the Giselle App. It initiates the execution of the connected nodes in a sequence. Currently, two types of Trigger Nodes are supported:


### PR DESCRIPTION
This PR updates the glossary to include the new WebPage Node.