### PR TITLE
docs: align contribution wording with closed-development policy

### DIFF
--- a/content/docs/en/guides/learn-about/open-source-license.mdx
+++ b/content/docs/en/guides/learn-about/open-source-license.mdx
@@ -14,5 +14,5 @@ However, it **does not** grant use of Giselle's **name, logo, or trademarks** wi
 
 If you have any questions or concerns regarding licensing or usage rights, please contact: **support@giselles.ai**
 
-We appreciate contributions from the community. For details on how to contribute, please refer to our [Contributing Guide](https://github.com/giselles-ai/giselle/blob/main/CONTRIBUTING.md).
+Giselle is developed by the core team, and we do not accept unsolicited external Pull Requests. That said, there are still many valuable ways to get involved—such as reporting bugs or sharing ideas. For details, please refer to our [Contributing Guide](https://github.com/giselles-ai/giselle/blob/main/CONTRIBUTING.md).
 

--- a/content/docs/ja/guides/learn-about/open-source-license.mdx
+++ b/content/docs/ja/guides/learn-about/open-source-license.mdx
@@ -14,5 +14,5 @@ Giselle Community Edition はオープンソースであり、[Apache License 2.
 
 ライセンスや使用権に関してご質問やご不明な点がございましたら、**support@giselles.ai** までお問い合わせください。
 
-コミュニティからの貢献を歓迎いたします。貢献方法の詳細については、[Contributing Guide](https://github.com/giselles-ai/giselle/blob/main/CONTRIBUTING.md) をご参照ください。
+Giselle はコアチームによって開発されており、招待のない外部からの Pull Request は受け付けておりません。一方で、バグ報告やアイデアの共有など、プロジェクトに関わっていただける方法は数多くあります。詳細については、[Contributing Guide](https://github.com/giselles-ai/giselle/blob/main/CONTRIBUTING.md) をご参照ください。
 


### PR DESCRIPTION
## Overview

In line with the shift to a closed-development policy (no unsolicited external PRs), this updates the contribution-soliciting text at the end of `open-source-license.mdx` (en / ja).

The Giselle [`CONTRIBUTING.md`](https://github.com/giselles-ai/giselle/blob/main/CONTRIBUTING.md) has been updated to a policy of not accepting unsolicited external PRs, while still describing other ways to get involved (bug reports, sharing ideas, etc.). The link is therefore kept, and only the wording is updated to match the new policy.

## Changes

- `content/docs/en/guides/learn-about/open-source-license.mdx`
- `content/docs/ja/guides/learn-about/open-source-license.mdx`

**Before (en)**
> We appreciate contributions from the community. For details on how to contribute, please refer to our Contributing Guide.

**After (en)**
> Giselle is developed by the core team, and we do not accept unsolicited external Pull Requests. That said, there are still many valuable ways to get involved—such as reporting bugs or sharing ideas. For details, please refer to our Contributing Guide.

## Verification

- [x] `pnpm format`
- [x] `pnpm build`
- [x] `pnpm check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)